### PR TITLE
Implement bottom navigation & new screens

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { StatusBar } from 'expo-status-bar';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
-import { View, Text, ScrollView, StyleSheet, ActivityIndicator } from 'react-native';
+import { View, Text, StyleSheet } from 'react-native';
 import * as Location from 'expo-location';
 import AppNavigator from './src/navigation/AppNavigator';
 import { ThemeProvider } from './src/contexts/ThemeContext';
@@ -10,11 +10,8 @@ import { shouldTriggerImport, importHolidayData, preloadHolidayImages } from './
 import JewishLoadingSpinner from './src/components/JewishLoadingSpinner';
 
 // Import services
-import { initializeActivities } from './src/services/activities';
-import { initializeNotifications, setupAllNotifications } from './src/services/notifications';
-import { getHebcalDayData, HebcalDayData } from './src/services/hebcalService';
-import { getActivitiesByDayType } from './src/services/activities';
-import { Activity } from './src/types/data';
+import { initializeNotifications } from './src/services/notifications';
+
 
 // Update the ErrorBoundary component props type
 interface ErrorBoundaryProps {
@@ -50,11 +47,7 @@ class ErrorBoundary extends React.Component<ErrorBoundaryProps> {
 
 export default function App() {
   const [isReady, setIsReady] = useState(false);
-  const [locationError, setLocationError] = useState<Error | null>(null);
   const [loadingMessage, setLoadingMessage] = useState('Loading...');
-  const [hebcalData, setHebcalData] = useState<HebcalDayData | null>(null);
-  const [activities, setActivities] = useState<Activity[]>([]);
-  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     async function prepare() {
@@ -116,29 +109,12 @@ export default function App() {
         setIsReady(true);
       } catch (e) {
         console.warn('Error during initialization:', e);
-        setLocationError(e as Error);
         // Continue without location data
         setIsReady(true);
       }
     }
 
     prepare();
-  }, []);
-
-  useEffect(() => {
-    async function loadData() {
-      try {
-        const data = await getHebcalDayData();
-        setHebcalData(data);
-        const dayActivities = await getActivitiesByDayType(data.dayType);
-        setActivities(dayActivities);
-      } catch (error) {
-        console.error('Error loading data:', error);
-      } finally {
-        setLoading(false);
-      }
-    }
-    loadData();
   }, []);
 
   if (!isReady) {
@@ -150,50 +126,12 @@ export default function App() {
     );
   }
 
-  if (loading) {
-    return (
-      <View style={styles.loadingContainer}>
-        <ActivityIndicator size="large" color="#0000ff" />
-        <Text>Loading...</Text>
-      </View>
-    );
-  }
-
-  if (!hebcalData) {
-    return (
-      <View style={styles.errorContainer}>
-        <Text style={styles.errorText}>Error loading data</Text>
-      </View>
-    );
-  }
-
   return (
     <ErrorBoundary>
       <ThemeProvider>
         <SafeAreaProvider>
           <StatusBar style="auto" />
-          <ScrollView style={styles.container}>
-            <Text style={styles.title}>Halacha Today</Text>
-            <Text style={styles.date}>📅 {hebcalData.date}</Text>
-            
-            <Text style={styles.subtitle}>📌 Events:</Text>
-            {hebcalData.events.map((event, index) => (
-              <Text key={index} style={styles.eventText}>• {event.name}</Text>
-            ))}
-
-            <Text style={styles.subtitle}>🔎 Activities for {hebcalData.dayType}:</Text>
-            {activities.map((activity) => (
-              <View key={activity.id} style={styles.activityContainer}>
-                <Text style={styles.activityTitle}>
-                  {activity.statusByDay[hebcalData.dayType] === 'allowed' ? '✅' : '❌'} {activity.title}
-                </Text>
-                <Text style={styles.activityDescription}>{activity.description}</Text>
-                <Text style={styles.activityExplanation}>
-                  {activity.explanation[hebcalData.dayType]}
-                </Text>
-              </View>
-            ))}
-          </ScrollView>
+          <AppNavigator />
         </SafeAreaProvider>
       </ThemeProvider>
     </ErrorBoundary>
@@ -202,11 +140,6 @@ export default function App() {
 
 // Styles for loading and error screens
 const styles = StyleSheet.create({
-  loadingContainer: {
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
   errorContainer: {
     flex: 1,
     justifyContent: 'center',
@@ -226,52 +159,5 @@ const styles = StyleSheet.create({
     fontSize: 14,
     color: '#666',
     marginTop: 10,
-  },
-  container: {
-    flex: 1,
-    padding: 20,
-    backgroundColor: '#fff',
-  },
-  title: {
-    fontSize: 28,
-    fontWeight: 'bold',
-    marginBottom: 10,
-    textAlign: 'center',
-  },
-  date: {
-    fontSize: 18,
-    marginBottom: 20,
-    textAlign: 'center',
-  },
-  subtitle: {
-    fontSize: 20,
-    fontWeight: 'bold',
-    marginTop: 20,
-    marginBottom: 10,
-  },
-  eventText: {
-    fontSize: 16,
-    marginBottom: 5,
-  },
-  activityContainer: {
-    backgroundColor: '#f5f5f5',
-    padding: 15,
-    borderRadius: 10,
-    marginBottom: 10,
-  },
-  activityTitle: {
-    fontSize: 18,
-    fontWeight: 'bold',
-    marginBottom: 5,
-  },
-  activityDescription: {
-    fontSize: 16,
-    color: '#666',
-    marginBottom: 5,
-  },
-  activityExplanation: {
-    fontSize: 14,
-    color: '#888',
-    fontStyle: 'italic',
   },
 });

--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -8,6 +8,8 @@ import * as Notifications from 'expo-notifications';
 import ActivityDetailsScreen from '../screens/ActivityDetailsScreen';
 import GoogleSignInScreen from '../screens/GoogleSignInScreen';
 import MainScreen from '../screens/MainScreen';
+import UpcomingEventsScreen from '../screens/UpcomingEventsScreen';
+import QuizScreen from '../screens/QuizScreen';
 
 // Import types
 import { RootStackParamList, MainTabParamList } from '../types/navigation';
@@ -30,12 +32,13 @@ const linking: LinkingOptions<RootStackParamList> = {
         screens: {
           Home: 'home',
           Activities: 'activities',
-          Calendar: 'calendar',
-          WhatCanIDo: 'whatcanido',
-          Settings: 'settings',
           Zmanim: 'zmanim',
+          Calendar: 'calendar',
+          Settings: 'settings',
         } as Record<keyof MainTabParamList, string>,
       },
+      UpcomingEvents: 'events',
+      Quiz: 'quiz',
       ActivityDetail: {
         path: 'activity/:activityId',
         parse: {
@@ -133,6 +136,16 @@ const AppNavigator = () => {
             name="Main"
             component={MainScreen}
             options={{ headerShown: false }}
+          />
+          <Stack.Screen
+            name="UpcomingEvents"
+            component={UpcomingEventsScreen}
+            options={{ title: 'Upcoming Events' }}
+          />
+          <Stack.Screen
+            name="Quiz"
+            component={QuizScreen}
+            options={{ title: 'Daily Quiz' }}
           />
           <Stack.Screen
             name="ActivityDetail"

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -91,15 +91,38 @@ const HomeScreen = () => {
             </View>
           )}
           <View style={styles.actionButtonsContainer}>
-            <TouchableOpacity style={[styles.actionButton, { backgroundColor: colors.accent1 }]} onPress={() => navigation.navigate('Main', { screen: 'Calendar' })}>
+            <TouchableOpacity
+              style={[styles.actionButton, { backgroundColor: colors.accent1 }]}
+              onPress={() => navigation.navigate('Main', { screen: 'Calendar' })}
+            >
               <Ionicons name="calendar-outline" size={24} color={colors.text} />
               <Text style={[styles.actionButtonText, { color: colors.text }]}>Calendar</Text>
             </TouchableOpacity>
-            <TouchableOpacity style={[styles.actionButton, { backgroundColor: colors.accent2 }]} onPress={() => navigation.navigate('Main', { screen: 'Activities' })}>
-              <Ionicons name="list-outline" size={24} color={colors.text} />
+            <TouchableOpacity
+              style={[styles.actionButton, { backgroundColor: colors.accent2 }]}
+              onPress={() => navigation.navigate('Main', { screen: 'Activities' })}
+            >
+              <Ionicons name="checkmark-circle-outline" size={24} color={colors.text} />
               <Text style={[styles.actionButtonText, { color: colors.text }]}>Activities</Text>
             </TouchableOpacity>
-            <TouchableOpacity style={[styles.actionButton, { backgroundColor: colors.accent3 }]} onPress={() => navigation.navigate('Main', { screen: 'Settings' })}>
+            <TouchableOpacity
+              style={[styles.actionButton, { backgroundColor: colors.accent3 }]}
+              onPress={() => navigation.navigate('UpcomingEvents')}
+            >
+              <Ionicons name="star-outline" size={24} color={colors.text} />
+              <Text style={[styles.actionButtonText, { color: colors.text }]}>Events</Text>
+            </TouchableOpacity>
+            <TouchableOpacity
+              style={[styles.actionButton, { backgroundColor: colors.accent1 }]}
+              onPress={() => navigation.navigate('Quiz')}
+            >
+              <Ionicons name="help-circle-outline" size={24} color={colors.text} />
+              <Text style={[styles.actionButtonText, { color: colors.text }]}>Quiz</Text>
+            </TouchableOpacity>
+            <TouchableOpacity
+              style={[styles.actionButton, { backgroundColor: colors.accent2 }]}
+              onPress={() => navigation.navigate('Main', { screen: 'Settings' })}
+            >
               <Ionicons name="settings-outline" size={24} color={colors.text} />
               <Text style={[styles.actionButtonText, { color: colors.text }]}>Settings</Text>
             </TouchableOpacity>

--- a/src/screens/MainScreen.tsx
+++ b/src/screens/MainScreen.tsx
@@ -57,4 +57,4 @@ const MainScreen = () => {
   );
 };
 
-export default MainScreen; 
+export default MainScreen;

--- a/src/screens/MainScreen.tsx
+++ b/src/screens/MainScreen.tsx
@@ -5,11 +5,10 @@ import { useTheme } from '../hooks/useTheme';
 
 // Import screens
 import HomeScreen from './HomeScreen';
-import ActivityListScreen from './ActivityListScreen';
 import CalendarScreen from './CalendarScreen';
 import SettingsScreen from './SettingsScreen';
 import WhatCanIDoScreen from './WhatCanIDoScreen';
-import ZmanimScreen from './ZmanimScreen'; // Assuming you'll create this later
+import ZmanimScreen from './ZmanimScreen';
 
 import { MainTabParamList } from '../types/navigation';
 
@@ -41,9 +40,8 @@ const MainScreen = () => {
           let iconName: keyof typeof Ionicons.glyphMap = 'home';
           if (route.name === 'Home') iconName = focused ? 'home' : 'home-outline';
           else if (route.name === 'Zmanim') iconName = focused ? 'time' : 'time-outline';
-          else if (route.name === 'Activities') iconName = focused ? 'list' : 'list-outline';
+          else if (route.name === 'Activities') iconName = focused ? 'checkmark-circle' : 'checkmark-circle-outline';
           else if (route.name === 'Calendar') iconName = focused ? 'calendar' : 'calendar-outline';
-          else if (route.name === 'WhatCanIDo') iconName = focused ? 'help-circle' : 'help-circle-outline';
           else if (route.name === 'Settings') iconName = focused ? 'settings' : 'settings-outline';
           return <Ionicons name={iconName} size={size} color={color} />;
         },
@@ -51,12 +49,10 @@ const MainScreen = () => {
       })}
     >
       <Tab.Screen name="Home" component={HomeScreen} />
-      <Tab.Screen name="Activities" component={ActivityListScreen} />
+      <Tab.Screen name="Activities" component={WhatCanIDoScreen} />
+      <Tab.Screen name="Zmanim" component={ZmanimScreen} />
       <Tab.Screen name="Calendar" component={CalendarScreen} />
-      <Tab.Screen name="WhatCanIDo" component={WhatCanIDoScreen} />
       <Tab.Screen name="Settings" component={SettingsScreen} />
-      {/* Assuming ZmanimScreen will be created for dedicated Zmanim view */}
-      <Tab.Screen name="Zmanim" component={ZmanimScreen} /> 
     </Tab.Navigator>
   );
 };

--- a/src/screens/QuizScreen.tsx
+++ b/src/screens/QuizScreen.tsx
@@ -1,0 +1,68 @@
+import React, { useState } from 'react';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { useTheme } from '../hooks/useTheme';
+
+const QuizScreen = () => {
+  const { colors } = useTheme();
+  const question = {
+    q: 'When does Shabbat begin?',
+    options: ['Sunrise', 'Sunset', 'Midnight'],
+    answer: 1,
+  };
+  const [selected, setSelected] = useState<number | null>(null);
+
+  return (
+    <View style={[styles.container, { backgroundColor: colors.background }]}>
+      <Text style={[styles.question, { color: colors.text }]}>{question.q}</Text>
+      {question.options.map((opt, idx) => (
+        <TouchableOpacity
+          key={opt}
+          style={[
+            styles.option,
+            {
+              borderColor: colors.border,
+              backgroundColor:
+                selected === null
+                  ? colors.card
+                  : idx === question.answer
+                  ? colors.allowed + '40'
+                  : idx === selected
+                  ? colors.forbidden + '40'
+                  : colors.card,
+            },
+          ]}
+          onPress={() => setSelected(idx)}
+        >
+          <Text style={{ color: colors.text }}>{opt}</Text>
+        </TouchableOpacity>
+      ))}
+      {selected !== null && (
+        <Text style={{ color: colors.textSecondary, marginTop: 12 }}>
+          {selected === question.answer ? 'Correct!' : 'Incorrect'}
+        </Text>
+      )}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    padding: 20,
+  },
+  question: {
+    fontSize: 22,
+    fontWeight: 'bold',
+    marginBottom: 20,
+    textAlign: 'center',
+  },
+  option: {
+    padding: 12,
+    marginBottom: 10,
+    borderWidth: 1,
+    borderRadius: 12,
+  },
+});
+
+export default QuizScreen;

--- a/src/screens/UpcomingEventsScreen.tsx
+++ b/src/screens/UpcomingEventsScreen.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { useTheme } from '../hooks/useTheme';
+
+const UpcomingEventsScreen = () => {
+  const { colors } = useTheme();
+  return (
+    <View style={[styles.container, { backgroundColor: colors.background }]}>
+      <Text style={[styles.title, { color: colors.text }]}>Upcoming Events</Text>
+      <Text style={{ color: colors.textSecondary }}>
+        Next event information will appear here.
+      </Text>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: 20,
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: 'bold',
+    marginBottom: 10,
+  },
+});
+
+export default UpcomingEventsScreen;

--- a/src/types/navigation.ts
+++ b/src/types/navigation.ts
@@ -3,21 +3,22 @@ import { DayType, CustomType } from './data';
 export type RootStackParamList = {
   GoogleSignIn: undefined;
   Main: undefined;
-  ActivityDetail: { 
+  ActivityDetail: {
     activityId: string;
     activityName?: string;
     dayType?: DayType;
     tradition?: CustomType;
   };
+  UpcomingEvents: undefined;
+  Quiz: undefined;
 };
 
 export type MainTabParamList = {
   Home: undefined;
-  Calendar: undefined;
-  Activities: { category?: string };
-  WhatCanIDo: undefined;
-  Settings: undefined;
+  Activities: undefined;
   Zmanim: undefined;
+  Calendar: undefined;
+  Settings: undefined;
 };
 
 /**


### PR DESCRIPTION
## Summary
- clean App entry and show AppNavigator
- extend navigation types with Upcoming Events and Quiz
- register new stack screens in AppNavigator
- adjust bottom tab layout in MainScreen
- add routes to open upcoming events and quiz from Home
- create simple UpcomingEventsScreen and QuizScreen

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6850e85793b0832ba7980fd3de742d33